### PR TITLE
Add Office update channel validation and update Electron dependency

### DIFF
--- a/Invoke-M365AppsHelper.ps1
+++ b/Invoke-M365AppsHelper.ps1
@@ -1325,8 +1325,31 @@ function New-DetectionScriptContent {
         [Parameter(Mandatory = $true)]
         [string]$DisplayName,
         [Parameter(Mandatory = $true)]
-        [string]$Version
+        [string]$Version,
+        [Parameter(Mandatory = $false)]
+        [string]$Channel
     )
+
+    # Map XML channel names to CDNBaseURL values
+    $channelCDNMap = @{
+        'BetaChannel'       = 'http://officecdn.microsoft.com/pr/5440fd1f-7ecb-4221-8110-145efaa6372f'
+        'CurrentPreview'    = 'http://officecdn.microsoft.com/pr/64256afe-f5d9-4f86-8936-8840a6a4f5be'
+        'Current'           = 'http://officecdn.microsoft.com/pr/492350f6-3a01-4f97-b9c0-c7c6ddf67d60'
+        'MonthlyEnterprise' = 'http://officecdn.microsoft.com/pr/55336b82-a18d-4dd6-b5f6-9e5095c314a6'
+        'SemiAnnualPreview' = 'http://officecdn.microsoft.com/pr/b8f9b850-328d-4355-9145-c59439a0c4cf'
+        'SemiAnnual'        = 'http://officecdn.microsoft.com/pr/7ffbc6bf-bc32-4f92-8982-f9dd17fd3114'
+    }
+
+    $expectedCDN = if ($Channel -and $channelCDNMap.ContainsKey($Channel)) { $channelCDNMap[$Channel] } else { '' }
+    $channelDisplayName = switch ($Channel) {
+        'BetaChannel'       { 'Beta Channel' }
+        'CurrentPreview'    { 'Current Channel (Preview)' }
+        'Current'           { 'Current Channel' }
+        'MonthlyEnterprise' { 'Monthly Enterprise Channel' }
+        'SemiAnnualPreview' { 'Semi-Annual Enterprise Channel (Preview)' }
+        'SemiAnnual'        { 'Semi-Annual Enterprise Channel' }
+        default             { $Channel }
+    }
     
     return @"
 <#
@@ -1335,17 +1358,20 @@ function New-DetectionScriptContent {
 
 .DESCRIPTION
     This script searches the Windows registry for Office installations matching
-    the specified DisplayName and verifies the installed version meets minimum requirements.
+    the specified DisplayName, verifies the installed version meets minimum requirements,
+    and validates the Office update channel via the CDNBaseURL registry value.
     Returns exit code 0 if detected, 1 if not detected.
 
 .NOTES
     Detection Method: Registry-based
     DisplayName: $DisplayName
     Minimum Version: $Version
+    Expected Channel: $channelDisplayName
 #>
 
 `$displayName = "$DisplayName"
 `$minVersion = [version]"$Version"
+`$expectedCDNBaseURL = "$expectedCDN"
 
 # Registry paths to check for installed apps
 `$registryPaths = @(
@@ -1395,6 +1421,16 @@ try {
     }
     
     if (`$found) {
+        # Check update channel via CDNBaseURL registry value
+        if (`$expectedCDNBaseURL) {
+            `$cdnRegPath = 'HKLM:\SOFTWARE\Microsoft\Office\ClickToRun\Configuration'
+            `$cdnValue = (Get-ItemProperty -Path `$cdnRegPath -Name 'CDNBaseUrl' -ErrorAction SilentlyContinue).CDNBaseUrl
+            if (`$cdnValue -ne `$expectedCDNBaseURL) {
+                Write-Output "Channel mismatch: Expected '`$expectedCDNBaseURL' but found '`$cdnValue'"
+                exit 1
+            }
+            Write-Output "Channel check passed: `$cdnValue"
+        }
         Write-Output "Detected: Office installation meets requirements"
         exit 0
     }
@@ -1420,12 +1456,14 @@ function New-DetectionScript {
         [string]$DisplayName,
         [Parameter(Mandatory = $true)]
         [string]$Version,
+        [Parameter(Mandatory = $false)]
+        [string]$Channel,
         [string]$LogID = $($MyInvocation.MyCommand).Name
     )
     
     try {
         $detectionScriptPath = Join-Path $OutputPath "Detect-OfficeInstallation.ps1"
-        $detectionScriptContent = New-DetectionScriptContent -DisplayName $DisplayName -Version $Version
+        $detectionScriptContent = New-DetectionScriptContent -DisplayName $DisplayName -Version $Version -Channel $Channel
         $detectionScriptContent | Out-File -FilePath $detectionScriptPath -Encoding UTF8 -Force
         Write-LogHost "Generated Detect-OfficeInstallation.ps1 for Win32 app detection" -ForegroundColor Green -Component $LogID
         
@@ -2622,7 +2660,7 @@ function Invoke-Main {
                 $intunewinFile = if ($CreateIntuneWin) { "setup.intunewin" } else { "[intunewin file]" }
                 
                 # Generate detection script
-                New-DetectionScript -OutputPath $sessionPath -DisplayName $customApp.AppsAndFeaturesName -Version $customApp.Version -LogID $LogID
+                New-DetectionScript -OutputPath $sessionPath -DisplayName $customApp.AppsAndFeaturesName -Version $customApp.Version -Channel $configInfo.Channel -LogID $LogID
                 
                 New-Win32AppInstructions -OutputPath $sessionPath -IntunewinFileName $intunewinFile -AppDetails $customApp -LogID $LogID
             }
@@ -2915,7 +2953,7 @@ function Invoke-Main {
                     $intunewinFile = if ($CreateIntuneWin) { "Microsoft365Apps.intunewin" } else { "[intunewin file]" }
                     
                     # Generate detection script
-                    New-DetectionScript -OutputPath $sessionPath -DisplayName $customApp.AppsAndFeaturesName -Version $customApp.Version -LogID $LogId
+                    New-DetectionScript -OutputPath $sessionPath -DisplayName $customApp.AppsAndFeaturesName -Version $customApp.Version -Channel $configInfo.Channel -LogID $LogId
                     
                     New-Win32AppInstructions -OutputPath $sessionPath -IntunewinFileName $intunewinFile -AppDetails $customApp -LogID $LogId
                 }

--- a/main.js
+++ b/main.js
@@ -1,6 +1,5 @@
 ﻿const { app, BrowserWindow, Menu, ipcMain, dialog, shell } = require('electron');
 const path = require('path');
-const isDev = require('electron-is-dev');
 const { spawn } = require('child_process');
 const fs = require('fs');
 
@@ -32,7 +31,6 @@ const createWindow = async () => {
     maxHeight: 1080,
     webPreferences: {
       contextIsolation: true,
-      enableRemoteModule: false,
       nodeIntegration: false,
       preload: path.join(__dirname, 'preload.js')
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,7 @@
       "name": "m365-apps-helper",
       "version": "1.0.0",
       "dependencies": {
-        "electron": "^28.1.0",
-        "electron-is-dev": "^2.0.0"
+        "electron": "^35.0.0"
       }
     },
     "node_modules/@electron/get": {
@@ -265,14 +264,14 @@
       "optional": true
     },
     "node_modules/electron": {
-      "version": "28.3.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-28.3.3.tgz",
-      "integrity": "sha512-ObKMLSPNhomtCOBAxFS8P2DW/4umkh72ouZUlUKzXGtYuPzgr1SYhskhFWgzAsPtUzhL2CzyV2sfbHcEW4CXqw==",
+      "version": "35.7.5",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-35.7.5.tgz",
+      "integrity": "sha512-dnL+JvLraKZl7iusXTVTGYs10TKfzUi30uEDTqsmTm0guN9V2tbOjTzyIZbh9n3ygUjgEYyo+igAwMRXIi3IPw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^18.11.18",
+        "@types/node": "^22.7.7",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -282,28 +281,19 @@
         "node": ">= 12.20.55"
       }
     },
-    "node_modules/electron-is-dev": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-2.0.0.tgz",
-      "integrity": "sha512-3X99K852Yoqu9AcW50qz3ibYBWY79/pBhlMCab8ToEWS48R0T9tyxRiQhwylE7zQdXrMnx2JKqUJyMPmt5FBqA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/electron/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/electron/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/end-of-stream": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "start": "electron ."
   },
   "dependencies": {
-    "electron": "^28.1.0",
-    "electron-is-dev": "^2.0.0"
+    "electron": "^35.0.0"
   }
 }


### PR DESCRIPTION
This PR does the following@

### Detection Script Enhancements:

* Added an optional `Channel` parameter to `New-DetectionScript` and `New-DetectionScriptContent` functions, allowing the expected Office update channel to be specified and passed through the detection script generation process. [[1]](diffhunk://#diff-b51c2a4775b760ef518d88d2d62692e144f52ad2c1e6af7b44ccee20646b2ee2L1328-R1374) [[2]](diffhunk://#diff-b51c2a4775b760ef518d88d2d62692e144f52ad2c1e6af7b44ccee20646b2ee2R1459-R1466) [[3]](diffhunk://#diff-b51c2a4775b760ef518d88d2d62692e144f52ad2c1e6af7b44ccee20646b2ee2L2625-R2663) [[4]](diffhunk://#diff-b51c2a4775b760ef518d88d2d62692e144f52ad2c1e6af7b44ccee20646b2ee2L2918-R2956)
* Implemented logic to map channel names to their corresponding CDN URLs and to check the installed Office's update channel via the `CDNBaseUrl` registry value. The detection script now exits with an error if the installed channel does not match the expected channel. [[1]](diffhunk://#diff-b51c2a4775b760ef518d88d2d62692e144f52ad2c1e6af7b44ccee20646b2ee2L1328-R1374) [[2]](diffhunk://#diff-b51c2a4775b760ef518d88d2d62692e144f52ad2c1e6af7b44ccee20646b2ee2R1424-R1433)
 
This change provides a longer-term anchor point for the detection script, especially useful in environments where multiple channels exist. 

### Electron App Cleanup:

* Removed the unused `electron-is-dev` dependency and related code from `main.js` and `package.json`, and dropped the deprecated `enableRemoteModule` option from the Electron window configuration. [[1]](diffhunk://#diff-58417e0f781b6656949d37258c8b9052ed266e2eb7a5163cad7b0863e6b2916aL3) [[2]](diffhunk://#diff-58417e0f781b6656949d37258c8b9052ed266e2eb7a5163cad7b0863e6b2916aL35) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L10-R10)

There was a flagged vulnerability for the shipped version of Electron. This updates that version and removes an unused dependency.